### PR TITLE
Fix in bug in golang library where bool was assumed to be an int

### DIFF
--- a/duouniversal/client.go
+++ b/duouniversal/client.go
@@ -59,15 +59,17 @@ func (f FlagStatus) MarshalJSON() ([]byte, error) {
 	switch f {
 	case Unknown:
 		return json.Marshal("unknown")
-	case Enabled, Disabled:
-		return json.Marshal(int32(f))
+	case Enabled:
+		return json.Marshal(true)
+	case Disabled:
+		return json.Marshal(false)
 	default:
 		return nil, errors.New("Error marshaling value")
 	}
 }
 
 func (f *FlagStatus) UnmarshalJSON(data []byte) error {
-	var i int32
+	var i bool
 	if err := json.Unmarshal(data, &i); err != nil {
 		var s string
 		if err := json.Unmarshal(data, &s); err != nil {
@@ -80,13 +82,12 @@ func (f *FlagStatus) UnmarshalJSON(data []byte) error {
 			return errors.New("Error unmarshaling value")
 		}
 	}
-	switch FlagStatus(i) {
-	case Enabled, Disabled:
-		*f = FlagStatus(i)
-		return nil
-	default:
-		return errors.New("Error unmarshaling value")
+	if i == true {
+		*f = FlagStatus(Enabled)
+	} else {
+		*f = FlagStatus(Disabled)
 	}
+	return nil
 }
 
 type HealthCheckTime struct {

--- a/duouniversal/client_test.go
+++ b/duouniversal/client_test.go
@@ -568,8 +568,8 @@ func TestMarshalingFlagStatus(t *testing.T) {
 		enumValue FlagStatus
 		jsonValue string
 	}{
-		{"Disabled marshaling", Disabled, "0"},
-		{"Enabled marshaling", Enabled, "1"},
+		{"Disabled marshaling", Disabled, "false"},
+		{"Enabled marshaling", Enabled, "true"},
 		{"Unknown marshaling", Unknown, "\"unknown\""},
 	}
 	for _, tc := range testCases {


### PR DESCRIPTION
The JSON response from the Duo API is a boolean rather than an integer. This commit changes the unmarshalling code accordingly. 