### PR TITLE
Add function to set a custom http client to the duo universal client

### DIFF
--- a/duouniversal/client.go
+++ b/duouniversal/client.go
@@ -242,6 +242,12 @@ func NewClientDuoCodeAttribute(clientId, clientSecret, apiHost, redirectUri stri
 	}, nil
 }
 
+// SetCustomHTTPClient allows one to set a completely custom http client that
+// will be used to make network calls to the duo api
+func (client *Client) SetCustomHTTPClient(c *http.Client) {
+	client.duoHttpClient = c
+}
+
 // Return a cryptographically-secure string of random characters
 // with the default length
 func (client *Client) GenerateState() (string, error) {


### PR DESCRIPTION
Hi from 1Password!

We are looking at add a function that we can use to override the default http client used by this duo package. Internally we have a configured http client that rejects certain calls based on specific security rules that we set. We have validation that ensures we only call out to a duo domain when using this package, but we like to have additional mitigations in place that may prevent any malicious calls to internal hosts.

Please let me know if this approach works for your team or if a different approach would be preferred.