### PR TITLE
Fix json label

### DIFF
--- a/duouniversal/client.go
+++ b/duouniversal/client.go
@@ -91,7 +91,7 @@ func (f *FlagStatus) UnmarshalJSON(data []byte) error {
 }
 
 type HealthCheckTime struct {
-	Time int `json:"time"`
+	Time int `json:"timestamp"`
 }
 
 type HealthCheckResponse struct {

--- a/duouniversal/client_test.go
+++ b/duouniversal/client_test.go
@@ -131,7 +131,7 @@ func TestHealthCheckGood(t *testing.T) {
         {
           "stat": "OK",
           "response": {
-            "time": 1357020061
+            "timestamp": 1357020061
           }
         }`
 
@@ -162,7 +162,7 @@ func TestHealthCheckFail(t *testing.T) {
           "message": "invalid_client",
           "message_detail": "The provided client_assertion was invalid",
           "response": {
-            "time": 1357020061
+            "timestamp": 1357020061
           }
         }`
 
@@ -184,7 +184,7 @@ func TestHealthCheckBadJSON(t *testing.T) {
         {
           "stat": "OK"
           "response": {
-            "time": 1357020061
+            "timestamp": 1357020061
           }
         }`
 


### PR DESCRIPTION
The json of the health check response looks like
```json
{"stat": "OK", "response": {"timestamp": 1668915039}}
```

Which is why `Time`'s json label needs to be changed to `timestamp`. I noticed `Time` was just set to 0, which didn't seem like it was intended.